### PR TITLE
Update package to Swift 5.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,18 @@
-// swift-tools-version:3.1
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-	name: "ShamirSecretSharing",
-	targets: [
-		Target(name: "ShamirSecretSharing", dependencies: ["libsss"])
-	]
+    name: "ShamirSecretSharing",
+    products: [
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+    .target(name: "libsss"),
+    .target(name: "ShamirSecretSharing", dependencies: ["libsss"]),
+    ]
 )

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These are the Swift bindings for my Shamir secret sharing library.
 
 ```shell
 # Clone and cd into the source code
-git clone --submodule https://github.com/dsprenkels/sss-swift.git
+git clone --recursive https://github.com/dsprenkels/sss-swift.git
 cd sss-swift
 
 # Build this package

--- a/Sources/ShamirSecretSharing/main.swift
+++ b/Sources/ShamirSecretSharing/main.swift
@@ -2,173 +2,173 @@ import libsss
 
 
 public enum CreateSharesError: Error {
-	case invalidInputLength
-	case invalidNParam
-	case invalidKParam
+    case invalidInputLength
+    case invalidNParam
+    case invalidKParam
 }
 
 public enum CombineSharesError: Error {
-	case sharesArrayEmpty
-	case badShareLength(Int)
+    case sharesArrayEmpty
+    case badShareLength(Int)
 }
 
 
 func checkNK(n: Int, k: Int) throws {
-	guard 1 <= n && n <= 255 else {
-		throw CreateSharesError.invalidNParam
-	}
-	guard 1 <= k && k <= n else {
-		throw CreateSharesError.invalidKParam
-	}
+    guard 1 <= n && n <= 255 else {
+        throw CreateSharesError.invalidNParam
+    }
+    guard 1 <= k && k <= n else {
+        throw CreateSharesError.invalidKParam
+    }
 }
 
 
 func checkDataLen(data: [UInt8]) throws {
-	guard data.count == sss_mlen else {
-		throw CreateSharesError.invalidInputLength
-	}
+    guard data.count == sss_mlen else {
+        throw CreateSharesError.invalidInputLength
+    }
 }
 
 
 func checkKeyLen(key: [UInt8]) throws {
-	guard key.count == 32 else {
-		throw CreateSharesError.invalidInputLength
-	}
+    guard key.count == 32 else {
+        throw CreateSharesError.invalidInputLength
+    }
 }
 
 
 func group(buf: UnsafeMutablePointer<UInt8>, group_size: Int, count: Int) -> [[UInt8]] {
-	// Put a buffer of results in a Swift array
-	var grouped:[[UInt8]] = []
-	grouped.reserveCapacity(count)
-	for i in 0..<count {
-		let offset = i * group_size
-		let cur = Array(UnsafeBufferPointer(start: buf + offset, count: group_size))
-		grouped.append(cur)
-	}
-	return grouped
+    // Put a buffer of results in a Swift array
+    var grouped:[[UInt8]] = []
+    grouped.reserveCapacity(count)
+    for i in 0..<count {
+        let offset = i * group_size
+        let cur = Array(UnsafeBufferPointer(start: buf + offset, count: group_size))
+        grouped.append(cur)
+    }
+    return grouped
 }
 
 
 public func CreateShares(data: [UInt8], n: Int, k: Int) throws -> [[UInt8]] {
-	try checkNK(n: n, k: k);
-	try checkDataLen(data: data);
+    try checkNK(n: n, k: k);
+    try checkDataLen(data: data);
 
-	// Call C API
-	let share_len = MemoryLayout<sss_Share>.size
-	let out = UnsafeMutablePointer<UInt8>.allocate(capacity: n * share_len)
-	defer {
-		out.deallocate(capacity: n * share_len)
-	}
-	out.withMemoryRebound(to: sss_Share.self, capacity: n) {
-		let cOutShares = $0
-		data.withUnsafeBufferPointer {
-			(cData: UnsafeBufferPointer<UInt8>) -> Void in
-			sss_create_shares(cOutShares, cData.baseAddress, UInt8(n), UInt8(k))
-		}
-	}
+    // Call C API
+    let share_len = MemoryLayout<sss_Share>.size
+    let out = UnsafeMutablePointer<UInt8>.allocate(capacity: n * share_len)
+    defer {
+        out.deallocate()
+    }
+    out.withMemoryRebound(to: sss_Share.self, capacity: n) {
+        let cOutShares = $0
+        data.withUnsafeBufferPointer {
+            (cData: UnsafeBufferPointer<UInt8>) -> Void in
+            sss_create_shares(cOutShares, cData.baseAddress, UInt8(n), UInt8(k))
+        }
+    }
 
-	return group(buf: out, group_size: share_len, count: n)
+    return group(buf: out, group_size: share_len, count: n)
 }
 
 
 public func CombineShares(shares: [[UInt8]]) throws -> [UInt8]? {
-	guard !shares.isEmpty else {
-		throw CombineSharesError.sharesArrayEmpty
-	}
-	let k = shares.count
+    guard !shares.isEmpty else {
+        throw CombineSharesError.sharesArrayEmpty
+    }
+    let k = shares.count
 
-	// Unpack Swift array
-	let share_len = MemoryLayout<sss_Share>.size
-	var cShares = UnsafeMutablePointer<UInt8>.allocate(capacity: k * share_len)
-	defer {
-		cShares.deallocate(capacity: k * share_len)
-	}
-	for i in 0..<k {
-		let share = shares[i]
-		guard share.count == share_len else {
-			throw CombineSharesError.badShareLength(i)
-		}
-		share.withUnsafeBufferPointer {
-			(cShare: UnsafeBufferPointer<UInt8>) -> Void in
-			let offset = i * share_len
-			(cShares + offset).assign(from: cShare.baseAddress!, count: share_len)
-		}
-	}
+    // Unpack Swift array
+    let share_len = MemoryLayout<sss_Share>.size
+    var cShares = UnsafeMutablePointer<UInt8>.allocate(capacity: k * share_len)
+    defer {
+        cShares.deallocate()
+    }
+    for i in 0..<k {
+        let share = shares[i]
+        guard share.count == share_len else {
+            throw CombineSharesError.badShareLength(i)
+        }
+        share.withUnsafeBufferPointer {
+            (cShare: UnsafeBufferPointer<UInt8>) -> Void in
+            let offset = i * share_len
+            (cShares + offset).assign(from: cShare.baseAddress!, count: share_len)
+        }
+    }
 
-	// Create data array
-	var dataArray:[UInt8] = Array.init(repeating: 0, count: sss_mlen)
+    // Create data array
+    var dataArray:[UInt8] = Array.init(repeating: 0, count: sss_mlen)
 
-	// Call C API
-	let retcode:Int = cShares.withMemoryRebound(to: sss_Share.self, capacity: k) {
-		let cInShares = $0
-		return dataArray.withUnsafeMutableBufferPointer {
-			(cData: inout UnsafeMutableBufferPointer<UInt8>) -> Int in
-			return Int(sss_combine_shares(cData.baseAddress, cInShares, UInt8(k)))
-		}
-	}
-	return retcode == 0 ? dataArray : nil
+    // Call C API
+    let retcode:Int = cShares.withMemoryRebound(to: sss_Share.self, capacity: k) {
+        let cInShares = $0
+        return dataArray.withUnsafeMutableBufferPointer {
+            (cData: inout UnsafeMutableBufferPointer<UInt8>) -> Int in
+            return Int(sss_combine_shares(cData.baseAddress, cInShares, UInt8(k)))
+        }
+    }
+    return retcode == 0 ? dataArray : nil
 }
 
 
 public func CreateKeyshares(key: [UInt8], n: Int, k: Int) throws -> [[UInt8]] {
-	try checkNK(n: n, k: k);
-	try checkKeyLen(key: key);
+    try checkNK(n: n, k: k);
+    try checkKeyLen(key: key);
 
-	// Call C API
-	let keyshare_len = MemoryLayout<sss_Keyshare>.size
-	let out = UnsafeMutablePointer<UInt8>.allocate(capacity: n * keyshare_len)
-	defer {
-		out.deallocate(capacity: n * keyshare_len)
-	}
-	out.withMemoryRebound(to: sss_Keyshare.self, capacity: n) {
-		let cOutKeyshares = $0
-		key.withUnsafeBufferPointer {
-			(cData: UnsafeBufferPointer<UInt8>) -> Void in
-			sss_create_keyshares(cOutKeyshares, cData.baseAddress, UInt8(n), UInt8(k))
-		}
-	}
+    // Call C API
+    let keyshare_len = MemoryLayout<sss_Keyshare>.size
+    let out = UnsafeMutablePointer<UInt8>.allocate(capacity: n * keyshare_len)
+    defer {
+        out.deallocate()
+    }
+    out.withMemoryRebound(to: sss_Keyshare.self, capacity: n) {
+        let cOutKeyshares = $0
+        key.withUnsafeBufferPointer {
+            (cData: UnsafeBufferPointer<UInt8>) -> Void in
+            sss_create_keyshares(cOutKeyshares, cData.baseAddress, UInt8(n), UInt8(k))
+        }
+    }
 
-	return group(buf: out, group_size: keyshare_len, count: n)
+    return group(buf: out, group_size: keyshare_len, count: n)
 }
 
 
 public func CombineKeyshares(keyshares: [[UInt8]]) throws -> [UInt8] {
-	guard !keyshares.isEmpty else {
-		throw CombineSharesError.sharesArrayEmpty
-	}
-	let k = keyshares.count
+    guard !keyshares.isEmpty else {
+        throw CombineSharesError.sharesArrayEmpty
+    }
+    let k = keyshares.count
 
-	// Unpack Swift array
-	let keyshare_len = MemoryLayout<sss_Keyshare>.size
-	var cKeyshares = UnsafeMutablePointer<UInt8>.allocate(capacity: k * keyshare_len)
-	defer {
-		cKeyshares.deallocate(capacity: k * keyshare_len)
-	}
-	for i in 0..<k {
-		let keyshare = keyshares[i]
-		guard keyshare.count == keyshare_len else {
-			throw CombineSharesError.badShareLength(i)
-		}
-		keyshare.withUnsafeBufferPointer {
-			(cKeyshare: UnsafeBufferPointer<UInt8>) -> Void in
-			let offset = i * keyshare_len
-			(cKeyshares + offset).assign(from: cKeyshare.baseAddress!, count: keyshare_len)
-		}
-	}
+    // Unpack Swift array
+    let keyshare_len = MemoryLayout<sss_Keyshare>.size
+    var cKeyshares = UnsafeMutablePointer<UInt8>.allocate(capacity: k * keyshare_len)
+    defer {
+        cKeyshares.deallocate()
+    }
+    for i in 0..<k {
+        let keyshare = keyshares[i]
+        guard keyshare.count == keyshare_len else {
+            throw CombineSharesError.badShareLength(i)
+        }
+        keyshare.withUnsafeBufferPointer {
+            (cKeyshare: UnsafeBufferPointer<UInt8>) -> Void in
+            let offset = i * keyshare_len
+            (cKeyshares + offset).assign(from: cKeyshare.baseAddress!, count: keyshare_len)
+        }
+    }
 
-	// Create data array
-	var keyArray:[UInt8] = Array.init(repeating: 0, count: 32)
+    // Create data array
+    var keyArray:[UInt8] = Array.init(repeating: 0, count: 32)
 
-	// Call C API
-	cKeyshares.withMemoryRebound(to: sss_Keyshare.self, capacity: k) {
-		let cInKeyshares = $0
-		keyArray.withUnsafeMutableBufferPointer {
-			(cKey: inout UnsafeMutableBufferPointer<UInt8>) in
-			sss_combine_keyshares(cKey.baseAddress, cInKeyshares, UInt8(k))
-		}
-	}
-	return keyArray
+    // Call C API
+    cKeyshares.withMemoryRebound(to: sss_Keyshare.self, capacity: k) {
+        let cInKeyshares = $0
+        keyArray.withUnsafeMutableBufferPointer {
+            (cKey: inout UnsafeMutableBufferPointer<UInt8>) in
+            sss_combine_keyshares(cKey.baseAddress, cInKeyshares, UInt8(k))
+        }
+    }
+    return keyArray
 }
 
 /*

--- a/Sources/ShamirSecretSharing/main.swift
+++ b/Sources/ShamirSecretSharing/main.swift
@@ -39,7 +39,7 @@ func checkKeyLen(key: [UInt8]) throws {
 
 func group(buf: UnsafeMutablePointer<UInt8>, group_size: Int, count: Int) -> [[UInt8]] {
     // Put a buffer of results in a Swift array
-    var grouped:[[UInt8]] = []
+    var grouped: [[UInt8]] = []
     grouped.reserveCapacity(count)
     for i in 0..<count {
         let offset = i * group_size
@@ -97,10 +97,10 @@ public func CombineShares(shares: [[UInt8]]) throws -> [UInt8]? {
     }
 
     // Create data array
-    var dataArray:[UInt8] = Array.init(repeating: 0, count: sss_mlen)
+    var dataArray: [UInt8] = Array.init(repeating: 0, count: sss_mlen)
 
     // Call C API
-    let retcode:Int = cShares.withMemoryRebound(to: sss_Share.self, capacity: k) {
+    let retcode: Int = cShares.withMemoryRebound(to: sss_Share.self, capacity: k) {
         let cInShares = $0
         return dataArray.withUnsafeMutableBufferPointer {
             (cData: inout UnsafeMutableBufferPointer<UInt8>) -> Int in
@@ -158,7 +158,7 @@ public func CombineKeyshares(keyshares: [[UInt8]]) throws -> [UInt8] {
     }
 
     // Create data array
-    var keyArray:[UInt8] = Array.init(repeating: 0, count: 32)
+    var keyArray: [UInt8] = Array.init(repeating: 0, count: 32)
 
     // Call C API
     cKeyshares.withMemoryRebound(to: sss_Keyshare.self, capacity: k) {


### PR DESCRIPTION
Current XCode does not support current package defined swift anymore (3.1)
Adjusted package file.

Removed dealloc with specified size as it is deprecated in Swift 5.1. Now deallocs entire heap block

Adjusted README listed command to work.